### PR TITLE
Ensure main.py is runnable standalone

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,10 @@
 """Entry point for PDF Slicer."""
 
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "src"))
+
 from pdf_slicer.gui import create_gui
 
 

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,8 @@ Run the application:
 python main.py
 ```
 
+`main.py` can be run directly without installing the package.
+
 From the GUI select the source PDF, choose the initial and final page and click **Export File**.
 
 ## Project Structure


### PR DESCRIPTION
## Summary
- allow running `main.py` without installing the package
- mention that the script can be executed standalone in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68408f6b84208321b347a9c81e83c4d1